### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ While the likelihood ratio test (LRT) is a more obvious choice for obtaining EIS
 
 ```r
 
-eisa <- getEISAcompR(exons=exon_counts, introns=intron_counts, design=design_matrix, filterExpr=TRUE, model="QLF", percent=0.5, cpm=1)
+eisa <- getEISAcompR(Exons=exon_counts, Introns=intron_counts, design=design_matrix, filterExpr=TRUE, model="QLF", percent=0.5, cpm=1)
 
 ```
 &nbsp;


### PR DESCRIPTION
As of today March 20, 2023;  EISAcompR version 0.1, `getEISAcompR` accepts arguments `Exons` & `Introns` BUT NOT `exons` & `introns`