### PR TITLE
add new functionality to fix error in GTF

### DIFF
--- a/R/writeEISAgtfs.R
+++ b/R/writeEISAgtfs.R
@@ -15,11 +15,21 @@
 #'@name writeEISAgtfs
 #'@rdname writeEISAgtfs-writeEISAgtfs
 #'@importFrom utils write.table
+
+removeNewlines <- function(subGTF){
+  corrctedGTF <- subGTF %>%
+                 dplyr::mutate(attrb = gsub("\n", "", attrb),
+                            start = as.integer(start),
+                            end = as.integer(end)
+                          )
+   return(corrctedGTF)
+  }
+
 writeEISAgtfs <- function(eisaR.obj, out.path="~/"){
 
-  exonGTF <- eisaR.obj$exonsGTF
-  intronGTF <- eisaR.obj$intronsGTF
-
+  exonGTF <- removeNewlines(eisaR.obj$exonsGTF)
+             
+  intronGTF <- removeNewlines(eisaR.obj$intronsGTF)
 
   ## Write GTFs
   utils::write.table(exonGTF, paste0(out.path,"Exons.gtf"), quote=F,


### PR DESCRIPTION
both `eisaR.obj$exonsGTF` and `eisaR.obj$intronsGTF` possess a column names `attrb` which contains `gene_id`, `gene_name` etc. Some of the values contains new line character and while executing `write.table` they are resulted in a separate entry causing errors.  Additionally some of the `start` and `end` remains as scientific notation, i.e. 1e+5 and that also resulted in error. Therefore, `removeNewlines` function is introduced to take care of the issues and write functional GTFs.